### PR TITLE
improve support for CMake and its caching of compiler path

### DIFF
--- a/py/csbuild
+++ b/py/csbuild
@@ -414,13 +414,6 @@ key event" + DEFAULT_HELP_SUFFIX)
             parser.error("options --git-bisect, --added-exit-code, --print-added, \
 --base-fail-exit-code, and --print-fixed make sense only with --git-commit-range")
 
-    if args.prep_cmd is not None:
-        # run the command given by --prep-cmd
-        scan_or_die(args.prep_cmd, "prep")
-
-    # create a temporary directory for the results
-    res_dir = tempfile.mkdtemp(prefix="csbuild")
-
     # prepare environment
     env = {}
     env["CSWRAP_TIMEOUT"] = "%d" % args.cswrap_timeout
@@ -436,6 +429,17 @@ key event" + DEFAULT_HELP_SUFFIX)
     for var in env:
         cmd_prefix += "%s='%s' " % (var, env[var])
 
+    # append path of the run-scan.sh script
+    cmd_prefix += RUN_SCAN_SH
+
+    # create a temporary directory for the results
+    res_dir = tempfile.mkdtemp(prefix="csbuild")
+    cmd_prefix += " " + shell_quote(res_dir)
+
+    if args.prep_cmd is not None:
+        # run the command given by --prep-cmd through run-scan.sh
+        scan_or_die(cmd_prefix + " " + shell_quote(args.prep_cmd), "prep")
+
     # chain all filters, starting with --embed-context propagation
     filter_cmd = "csgrep --embed-context %d" % args.embed_context
     if repo is not None:
@@ -443,10 +447,8 @@ key event" + DEFAULT_HELP_SUFFIX)
         filter_cmd += ' | csgrep --path "^%s/" --strip-path-prefix "%s/"' \
                 % (repo_dir, repo_dir)
 
-    # prepare template for running the run-scan.sh script
-    cmd = "%s %s %s %s %s" % (
-        cmd_prefix, RUN_SCAN_SH,
-        shell_quote(res_dir),
+    # prepare template for running build_cmd through the run-scan.sh script
+    cmd = "%s %s %s" % (cmd_prefix,
         shell_quote(args.build_cmd),
         shell_quote(filter_cmd))
 


### PR DESCRIPTION
```
csbuild: check CMakeCache.txt for incorrectly cached compiler path
  
... in case the file exists and the corresponding variables are cached.
If the cached path does not match the expected path in our modified env,
do not start the build as it would likely run without compiler wrappers
in effect.
```

Fixes #13 

```
csbuild --prep-cmd: run the command through run-scan.sh

... so that the same environment is used.  This is needed if 'cmake'
runs as --prep-cmd because it caches the absolute path of the compiler
(or compiler wrapper in our case).
```

Fixes #13 