### PR TITLE
chroot-fixups/openssl-public-header-files.sh: enable warnings

### DIFF
--- a/scripts/chroot-fixups/openssl-public-header-files.sh
+++ b/scripts/chroot-fixups/openssl-public-header-files.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if test -w /usr/include/openssl/e_os2.h; then
+    (set -x
+
+    # behave as if the code was preprocessed with -DDEBUG_UNUSED
+    sed -i /usr/include/openssl/e_os2.h \
+        -e 's|\(# *if\)def DEBUG_UNUSED|\1 1|')
+fi


### PR DESCRIPTION
... about unused return values of functions that may start to fail after update of openssl or the system crypto policy.