### PR TITLE
csmock: do not hard-wire ordering of plug-ins

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # Copyright (C) 2012-2018 Red Hat, Inc.
 #

--- a/py/csmock
+++ b/py/csmock
@@ -480,8 +480,10 @@ class ScanProps:
 
 class PluginManager:
     def __init__(self):
-        self.plug_by_prio = {}
+        self.plugins_sorted = []
         self.plug_by_name = {}
+        self.pass_before = {}
+        self.pass_after = {}
 
     def try_load(self, mod_name):
         full_name = "csmock.plugins." + mod_name
@@ -490,15 +492,45 @@ class PluginManager:
 
         props = plugin.get_props()
         # TODO: check API version
-        prio = props.pass_priority
-        assert prio not in self.plug_by_prio
-        self.plug_by_prio[prio] = plugin
+        if hasattr(props, "pass_priority"):
+            sys.stderr.write("%s: %s: ignoring pass_priority = %s defined by %s\n"
+                    % (sys.argv[0], self.__class__.__name__, str(props.pass_priority), mod))
+        for attr in ["pass_before", "pass_after"]:
+            if hasattr(props, attr):
+                getattr(self, attr)[mod_name] = getattr(props, attr)
         self.plug_by_name[mod_name] = plugin
+
+    # TODO: use graphlib.TopologicalSorter once we drop python2 support
+    def sort_topologically(self):
+        graph = {}
+        for plug in self.plug_by_name.keys():
+            graph[plug] = set()
+        for plug in self.pass_before.keys():
+            for before in self.pass_before[plug]:
+                if before in self.plug_by_name.keys():
+                    graph[before].add(plug)
+        for plug in self.pass_after.keys():
+            for after in self.pass_after[plug]:
+                if after in self.plug_by_name.keys():
+                    graph[plug].add(after)
+        # FIXME: lame placeholder for the topological sort implementation
+        order = []
+        for plug in sorted(self.plug_by_name.keys()):
+            for after in sorted(graph[plug]):
+                if after not in order:
+                    order += [after]
+        for plug in sorted(self.plug_by_name.keys()):
+            if plug not in order:
+                order += [plug]
+        self.plugins_sorted = []
+        for plug in order:
+            self.plugins_sorted += [self.plug_by_name[plug]]
 
     def load_default_plugins(self):
         pkg = importlib.import_module("csmock.plugins")
         for (_, mod_name, _) in pkgutil.iter_modules(pkg.__path__):
             self.try_load(mod_name)
+        self.sort_topologically()
 
     # Print description of each available plugin in format TOOL [:indent:] DESCRIPTION
     def print_plugin_descriptions(self):
@@ -519,27 +551,23 @@ class PluginManager:
         plugin.enable()
 
     def enable_all(self):
-        for prio in sorted(self.plug_by_prio):
-            plugin = self.plug_by_prio[prio]
+        for plugin in self.plugins_sorted:
             experimental= getattr(plugin.get_props(), "experimental", False)
             if experimental:
                 continue
             plugin.enable()
 
     def init_parser(self, parser):
-        for prio in sorted(self.plug_by_prio):
-            plugin = self.plug_by_prio[prio]
+        for plugin in self.plugins_sorted:
             plugin.init_parser(parser)
 
     def handle_args(self, parser, args, props):
-        for prio in sorted(self.plug_by_prio):
-            plugin = self.plug_by_prio[prio]
+        for plugin in self.plugins_sorted:
             plugin.handle_args(parser, args, props)
 
     def num_enabled(self):
         cnt = 0
-        for prio in sorted(self.plug_by_prio):
-            plugin = self.plug_by_prio[prio]
+        for plugin in self.plugins_sorted:
             if getattr(plugin, "enabled", False):
                 cnt = cnt + 1
         return cnt

--- a/py/plugins/bandit.py
+++ b/py/plugins/bandit.py
@@ -27,7 +27,6 @@ FILTER_CMD = "csgrep --quiet '%s' | csgrep --event '%s' > '%s'"
 
 class PluginProps:
     def __init__(self):
-        self.pass_priority = 0x44
         self.description = "A tool designed to find common security issues in Python code."
         self.experimental = True
 

--- a/py/plugins/clang.py
+++ b/py/plugins/clang.py
@@ -26,7 +26,6 @@ import csmock.common.util
 
 class PluginProps:
     def __init__(self):
-        self.pass_priority = 0x30
         self.description = "Source code analysis tool that finds bugs in C, C++, and Objective-C programs."
 
 

--- a/py/plugins/cppcheck.py
+++ b/py/plugins/cppcheck.py
@@ -25,7 +25,6 @@ import csmock.common.cflags
 
 class PluginProps:
     def __init__(self):
-        self.pass_priority = 0x20
         self.description = "Static analysis tool for C/C++ code."
 
 

--- a/py/plugins/gcc.py
+++ b/py/plugins/gcc.py
@@ -27,7 +27,6 @@ CSGCCA_BIN="/usr/bin/csgcca"
 
 class PluginProps:
     def __init__(self):
-        self.pass_priority = 0x10
         self.description = "Plugin capturing GCC warnings, optionally with customized compiler flags."
 
 
@@ -182,7 +181,7 @@ class Plugin:
 
                 props.env["CSWRAP_TIMEOUT_FOR"] += ":gcc"
                 if args.gcc_analyze_add_flag:
-                    # propagate custom clang flags
+                    # propagate custom GCC analyzer flags
                     props.env["CSGCCA_ADD_OPTS"] = csmock.common.cflags.serialize_flags(args.gcc_analyze_add_flag)
 
                 # record that `gcc -fanalyzer` was used for this scan

--- a/py/plugins/pylint.py
+++ b/py/plugins/pylint.py
@@ -29,7 +29,6 @@ FILTER_CMD = "csgrep --quiet '%s' " \
 
 class PluginProps:
     def __init__(self):
-        self.pass_priority = 0x50
         self.description = "Python source code analyzer which looks for programming errors.\n" \
                            "Helps enforcing a coding standard and sniffs for some code smells."
 

--- a/py/plugins/shellcheck.py
+++ b/py/plugins/shellcheck.py
@@ -29,7 +29,6 @@ FILTER_CMD = "csgrep --quiet '%s' " \
 
 class PluginProps:
     def __init__(self):
-        self.pass_priority = 0x58
         self.description = "A static analysis tool that gives warnings and suggestions for bash/sh shell scripts."
 
 

--- a/py/plugins/smatch.py
+++ b/py/plugins/smatch.py
@@ -25,7 +25,6 @@ import csmock.common.util
 
 class PluginProps:
     def __init__(self):
-        self.pass_priority = 0x38
         self.experimental = True
         self.description = "Source code analysis for C, based on sparse."
 

--- a/py/plugins/strace.py
+++ b/py/plugins/strace.py
@@ -24,11 +24,11 @@ STRACE_CAPTURE_DIR = "/builddir/strace-capture"
 
 class PluginProps:
     def __init__(self):
-        # FIXME: This needs to be lower than priority of the "gcc" plugin
-        # for ScanProps::enable_csexec() to work.
-        self.pass_priority = 0x02
         self.experimental = True
         self.description = "A dynamic analysis tool that records system calls associated with a running process."
+
+        # hook this plug-in before "gcc" to make ScanProps:enable_csexec() work
+        self.pass_before = ["gcc"]
 
 
 class Plugin:

--- a/py/plugins/valgrind.py
+++ b/py/plugins/valgrind.py
@@ -26,11 +26,11 @@ DEFAULT_VALGRIND_TIMEOUT = 30
 
 class PluginProps:
     def __init__(self):
-        # FIXME: This needs to be lower than priority of the "gcc" plugin
-        # for ScanProps::enable_csexec() to work.
-        self.pass_priority = 0x01
         self.description = "A dynamic analysis tool for finding memory management bugs in programs."
         self.experimental = True
+
+        # hook this plug-in before "gcc" to make ScanProps:enable_csexec() work
+        self.pass_before = ["gcc"]
 
 
 class Plugin:


### PR DESCRIPTION
Instead of assigning unique numbers to each plug-in, let them define
relative dependencies via the "pass_before" and "pass_after" attributes
of PluginProps.

The topological sorting is not yet fully implemented because we would
like to use graphlib.TopologicalSorter which is not available in
python-2, which we still care about.

Note that, when the order is otherwise unspecified, the plug-ins are
sorted alphabetically by their names.  This is an observable change
in behavior, compared to how it worked before.